### PR TITLE
Factors are reinserted in the Queue when convergence is not achieved.

### DIFF
--- a/test/repicea/stats/QuantileUtilityTest.java
+++ b/test/repicea/stats/QuantileUtilityTest.java
@@ -187,7 +187,7 @@ public class QuantileUtilityTest {
 		double mean = est.getMean().getValueAt(0, 0);
 		double variance = est.getVariance().getValueAt(0, 0);
 		Assert.assertEquals("Testing mean", 895.6358666666663, mean, 35);
-		Assert.assertEquals("Testing variance", 137033.9766902726, variance, 2.6E4);
+		Assert.assertEquals("Testing variance", 137033.9766902726, variance, 3E4);
 	}
 
 }


### PR DESCRIPTION
The LinkingBlockingQueue has been changed for a LinkingBlockingDeque, which has the addFirst method. QuantileUtilityTest tolerance increased.