### PR TITLE
42 truncated negative binomial

### DIFF
--- a/src/repicea/stats/distributions/utility/NegativeBinomialUtility.java
+++ b/src/repicea/stats/distributions/utility/NegativeBinomialUtility.java
@@ -82,4 +82,19 @@ public class NegativeBinomialUtility {
 		}
 	}
 
+	/**
+	 * Provide a quantile of the distribution.
+	 * @param the cumulative mass
+	 * @return a quantile
+	 */
+	public static int getQuantile(double cdfValue, double mean, double dispersion) {
+		if (cdfValue < 0 || cdfValue > 1) 
+			throw new InvalidParameterException("The cdfValue parameter should be a double between 0 and 1!");
+		double cumulativeMass = 0d;
+		int y = 0;
+		while(cumulativeMass < cdfValue) 
+			cumulativeMass += getMassProbability(y++, mean, dispersion); 
+		return --y;
+	}
+
 }

--- a/src/repicea/stats/distributions/utility/NegativeBinomialUtility.java
+++ b/src/repicea/stats/distributions/utility/NegativeBinomialUtility.java
@@ -50,8 +50,14 @@ public class NegativeBinomialUtility {
 	}
 	
 	/**
-	 * This method returns the mass probability from a negative binomial distribution for a particular integer. It follows the 
-	 * SAS parameterization.
+	 * The mass probability of a negative binomial distribution.<br>
+	 * <br>
+	 * It follows the SAS parameterization: <br>
+	 * <br>
+	 * Pr(y)= r(y + 1/theta)/(y! r(1/theta)) * (theta*mu)^y / (1+theta*mu)^(y + 1/theta)<br>
+	 * <br>
+	 * where r() stands for the Gamma function.
+	 *  
 	 * @see<a href=http://support.sas.com/documentation/cdl/en/statug/63033/HTML/default/viewer.htm#statug_genmod_sect030.htm> 
 	 * SAS online documentation </a>
 	 * @param y the count (must be equal to or greater than 0)
@@ -62,14 +68,18 @@ public class NegativeBinomialUtility {
 	public static double getMassProbability(int y, double mean, double dispersion) {
 		if (y < 0) {
 			throw new InvalidParameterException("The binomial distribution is designed for integer equals to or greater than 0!");
+		} else if (y == 0) {
+			double dispersionTimesMean = dispersion * mean;
+			double inverseDispersion = 1/dispersion;
+			double prob = 1d / (Math.pow(1+dispersionTimesMean, inverseDispersion));
+			return prob;
+		} else {
+			double dispersionTimesMean = dispersion * mean;
+			double inverseDispersion = 1/dispersion;
+			double prob = GammaUtility.gamma(y + inverseDispersion) / (MathUtility.Factorial(y) * GammaUtility.gamma(inverseDispersion)) 
+					*  Math.pow(dispersionTimesMean,y) / (Math.pow(1+dispersionTimesMean,y + inverseDispersion));
+			return prob;
 		}
-		double prob = 0.0;
-		double dispersionTimesMean = dispersion * mean;
-		double inverseDispersion = 1/dispersion;
-		
-		prob = GammaUtility.gamma(y + inverseDispersion) / (MathUtility.Factorial(y) * GammaUtility.gamma(inverseDispersion)) 
-				*  Math.pow(dispersionTimesMean,y) / (Math.pow(1+dispersionTimesMean,y + inverseDispersion));
-		return prob;
 	}
 
 }

--- a/src/repicea/stats/model/glm/GeneralizedLinearModel.java
+++ b/src/repicea/stats/model/glm/GeneralizedLinearModel.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import repicea.math.MathematicalFunction;
 import repicea.math.Matrix;
-import repicea.math.SymmetricMatrix;
 import repicea.stats.data.DataSet;
 import repicea.stats.data.GenericStatisticalDataStructure;
 import repicea.stats.data.StatisticalDataException;

--- a/test/repicea/stats/distributions/ChiSquaredTest.java
+++ b/test/repicea/stats/distributions/ChiSquaredTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import repicea.math.Matrix;
 import repicea.math.SymmetricMatrix;
 
-public class ChiSquaredUtilityTest {
+public class ChiSquaredTest {
 
 	@Test
 	public void randomGenerationTestForUnivariateChiSquared() {

--- a/test/repicea/stats/distributions/utility/NegativeBinomialUtilityTest.java
+++ b/test/repicea/stats/distributions/utility/NegativeBinomialUtilityTest.java
@@ -57,6 +57,12 @@ public class NegativeBinomialUtilityTest {
 		Assert.assertEquals("Testing the two methods", observed, observed2, 1E-8);
 	}
 
+	@Test
+	public void zeroValueFasterImplementationTest() {
+		double observed = NegativeBinomialUtility.getMassProbability(0, 1, 1);
+		double observed2 = NegativeBinomialUtility.getMassProbabilityOLD(0, 1, 1);
+		Assert.assertEquals("Testing the two methods", observed, observed2, 1E-8);
+	}
 	
 	
 

--- a/test/repicea/stats/distributions/utility/NegativeBinomialUtilityTest.java
+++ b/test/repicea/stats/distributions/utility/NegativeBinomialUtilityTest.java
@@ -21,6 +21,10 @@ package repicea.stats.distributions.utility;
 import org.junit.Assert;
 import org.junit.Test;
 
+import repicea.math.Matrix;
+import repicea.stats.StatisticalUtility;
+import repicea.stats.estimates.MonteCarloEstimate;
+
 
 public class NegativeBinomialUtilityTest {
 
@@ -64,6 +68,47 @@ public class NegativeBinomialUtilityTest {
 		Assert.assertEquals("Testing the two methods", observed, observed2, 1E-8);
 	}
 	
-	
+	@Test
+	public void quantileTest1() {
+		int observed = NegativeBinomialUtility.getQuantile(0.5, 1, .8);
+		Assert.assertEquals("Testing a quantile", 1, observed);
+	}
+
+	@Test
+	public void meanTest1() {
+		double mu = 1d;
+		double theta = .8;
+		MonteCarloEstimate est = new MonteCarloEstimate();
+		int nbRealizations = 50000;
+		for (int i = 0; i < nbRealizations; i++) {
+			int observed = NegativeBinomialUtility.getQuantile(StatisticalUtility.getRandom().nextDouble(),
+					mu, 
+					theta);
+			est.addRealization(new Matrix(1,1,observed,0));
+		}
+		double mean = est.getMean().getValueAt(0, 0);
+		double variance = est.getVariance().getValueAt(0, 0);
+		Assert.assertEquals("Testing the mean", mu, mean, 1E-2);
+		Assert.assertEquals("Testing the variance", mu + theta*mu*mu, variance, 3E-2);
+	}
+
+
+	@Test
+	public void meanTest2() {
+		double mu = 1.5;
+		double theta = .5;
+		MonteCarloEstimate est = new MonteCarloEstimate();
+		int nbRealizations = 50000;
+		for (int i = 0; i < nbRealizations; i++) {
+			int observed = NegativeBinomialUtility.getQuantile(StatisticalUtility.getRandom().nextDouble(),
+					mu, 
+					theta);
+			est.addRealization(new Matrix(1,1,observed,0));
+		}
+		double mean = est.getMean().getValueAt(0, 0);
+		double variance = est.getVariance().getValueAt(0, 0);
+		Assert.assertEquals("Testing the mean", mu, mean, 1E-2);
+		Assert.assertEquals("Testing the variance", mu + theta*mu*mu, variance, 3E-2);
+	}
 
 }


### PR DESCRIPTION
The truncated negative binomial was not implemented in the end. This was because the second derivative of the theta parameter is too complex. However, the NegativeBinomialUtility class was improved.